### PR TITLE
* renamed IS_CAPTALIZED() to CAPITALIZE()

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -7,9 +7,11 @@
 # ---- example index page ----
 @auth.requires_membership('admin')
 def index():
-    smartgrid = SQLFORM.smartgrid(db.dossier,
-                                  links=[lambda r: A('Dossier bekijken', _href=URL('default', 'dossier', vars=dict(dossier=r.id))) if 'view' in request.args or not request.vars['_signature'] else ''])
-    return dict(smartgrid=smartgrid)
+    grid = SQLFORM.grid(db.dossier,
+                                  links=[lambda r: A('Dossier bekijken', _href=URL('default', 'dossier', vars=dict(
+                                      dossier=r.id))) if 'view' in request.args or not request.vars[
+                                      '_signature'] else ''])
+    return dict(grid=grid)
 
 
 @auth.requires_membership('admin')
@@ -18,7 +20,7 @@ def dossier():
     if not dossier_id:
         return 'OEPS! er is geen dossier geselecteerd.'
 
-    dossier = db.dossier[dossier_id]
+    dossier = db(db.dossier.id == dossier_id).select().first()
     if not dossier:
         return 'OEPS! dit dossier bestaat niet (meer).'
 
@@ -30,8 +32,8 @@ def dossier():
 
     # using constraints to execute a query with in a smartgrid, we're using this to only get the
     # dienstverband records of this current dossier.
-    dienstverbanden = SQLFORM.smartgrid(db.dienstverband, constraints=dict(dienstverband=query))
-
+    dienstverbanden = SQLFORM.smartgrid(db.dienstverband, constraints=dict(dienstverband=query),
+                                        onvalidation=NO_ROLE_OVERLAP)
     if form.process().accepted:
         response.flash = 'Wijzigingen opgeslagen.'
 

--- a/models/db_functions.py
+++ b/models/db_functions.py
@@ -1,35 +1,87 @@
 import datetime
 
 
-def current_dienstverbanden(dossier_id):
+def NO_ROLE_OVERLAP(form):
+    """Validator to check whether or not the selected role is overlapping with a role that is already assigned to a
+    dossier in the given period of time.
+
+    Example:
+        Usage:
+            form = SQLFORM()
+            if form.process(onvalidation=NO_ROLE_OVERLAP).accepted
+
+    this should only be used with a form that interacts with the db.dienstverband table
+    """
+    if not form.vars.rol_id:
+        form.errors.rol_id = 'Selecteer een rol om toe te wijzen aan dit dossier'
+        return
+    # form.vars.dossier_id doesn't work here. as the dossier_id doesn't get submitted with the form vars.
+    if form.record:
+        dienstverbanden = active_dienstverbanden(form.record.dossier_id)
+    else:
+        dienstverbanden = active_dienstverbanden(request.vars['dossier'])
+    begin_date = form.vars.begindatum
+    roles = form.vars.rol_id
+    # checking the instance, because even with a field that can handle multiple inputs,
+    # sometimes you just want one input.
+    if isinstance(roles, (tuple, list)):
+        # inherit the instance if the value is already a tuple or a list
+        roles = roles
+    else:
+        # creating a list of values from value
+        roles = [roles]
+
+    current_dienstverband = form.record.id if form.record else []
+    override = None
+    if current_dienstverband:
+        # selecting the record, because check_conflicts() creates a list of conflicting records
+        # we use this to remove the current record from that list.
+        override = db(db.dienstverband.id == current_dienstverband).select().first()
+
+    for role in roles:
+        conflicting = check_conflicts(active_dienstverbanden=dienstverbanden,
+                                      role=role,
+                                      begin_date=begin_date,
+                                      override=override)
+        if conflicting:
+            form.errors.rol_id = 'Een of meerdere rollen zijn al toegewezen aan dit dossier tijdens de gekozen periode.'
+            return
+
+
+def active_dienstverbanden(dossier_id):
     """Gets the currently active 'dienstverband' records assigned to a dossier.
 
     :param dossier_id: id of the dossier you want the dienstverband records of
     :return: list of dienstverband records
     """
-    rows = db(db.dienstverband.dossier_id == dossier_id).select()
     today = datetime.date.today()
-    # dienstverbanden = [_ for _ in rows if _.einddatum >= today >= _.begindatum if not None]
-    dienstverbanden = [r for r in rows if r.einddatum is not None and r.einddatum >= today >= r.begindatum if not None]
+    query = (db.dienstverband.dossier_id == dossier_id) & (db.dienstverband.begindatum <= today)
+    query &= (db.dienstverband.einddatum >= today) | (db.dienstverband.einddatum == None)
+    rows = db(query).select()
+    # creating list of all rows given by the select statement
+    dienstverbanden = [r for r in rows]
     return dienstverbanden
 
 
-def check_conflicts(active_dienstverbanden, role, begin_date=None):
+def check_conflicts(active_dienstverbanden, role, override, begin_date=None):
     """Checks if there are any duplicate roles in the given period of time.
 
     :param active_dienstverbanden: the 'dienstverband' records you need to check, use current_dienstverbanden() for this.
-    :param role: the rol record you need to check for.
+    :param role: a rol_id you need to check for
+    :param override: the record that's allowed to be overridden
     :param begin_date: the starting date of the new 'dienstverband' record.
     :return: either True or False
     """
     if begin_date:
-        begin = datetime.datetime.strptime(begin_date, '%Y-%m-%d')
         # creating a list of records that have the same role as the role we're trying to assign for the given time
-        # period. we're checking if role.id is in _.rol_id because _.rol_id is a list of roles assigned to a
+        # period. we're checking if role is in r.rol_id because r.rol_id is a list of roles assigned to a
         # 'dienstverband' record. because we're allowing for multiple roles to be selected and the field is a list of
         # references, we always need to check if the value exists within the list.
-        conflicts = [_ for _ in active_dienstverbanden if role.id in _.rol_id and _.einddatum >= begin.date()]
-        return True if conflicts else False
+        conflicts = [r for r in active_dienstverbanden if int(role) in r.rol_id if not r.einddatum == None]
+        # override is the current record we're trying to edit, so it will be removed from the list of conflicts.
+        if override:
+            conflicts.remove(override) if override in conflicts else []
+        return bool(conflicts)
     # obviously, if no begin date has been given, this role can't overlap
     else:
         return False

--- a/models/db_persona.py
+++ b/models/db_persona.py
@@ -1,70 +1,4 @@
-class NO_ROLE_OVERLAP:
-    """Validator to check whether or not the selected role is overlapping with a role that is already assigned to a
-    dossier in the given period of time.
-
-    Example:
-        Usage:
-        Field('rol', 'list:reference rol', requires=NO_ROLE_OVERLAP())
-
-    used for reference fields, rendered as a dropbox.
-    """
-
-    def __init__(self, multiple=True,
-                 error_message='Een of meerdere rollen zijn tijdens deze periode al toegewezen aan dit dossier'):
-        self.error_message = error_message
-        self.roles = db(db.rol.id > 0).select()  # we're working with every role in the database for the options field
-        self.multiple = multiple  # multiple=True because we're allowing for multiple roles to be selected
-
-    def __call__(self, value):
-        try:
-            return self.validate(value)
-        except Exception:
-            raise
-
-    def options(self):
-        # creating a list of tuples, this way web2py can create a SELECT object
-        items = [(_.id, _.naam) for _ in self.roles]
-        # inserting an extra option, so the default field is blank, this way we make sure
-        # that items will be selected properly
-        items.insert(0, ("", ""))
-        return items
-
-    def validate(self, value):
-        # if there is no role selected, there's nothing to validate. also, this field is not allowed to be empty.
-        if not value:
-            self.error_message = 'Dit veld mag niet leeg zijn'
-            return value, self.error_message
-
-        # this allows for editing the 'dienstverbanden', it ignores the validation
-        if 'edit' in request.url:  # TODO: might need to change later, works for now
-            return value, None
-
-        # getting all of the records that are currently active for this dossier
-        dienstverbanden = current_dienstverbanden(request.vars.dossier_id)
-        begin = request.vars.begindatum
-        # checking the instance, because even with a field that can handle multiple inputs,
-        # sometimes you just want one input.
-        if isinstance(value, (tuple, list)):
-            # inherit the instance if the value is already a tuple or a list
-            values = value
-        else:
-            # creating a list of values from value
-            values = [value]
-        for role_id in values:
-            # getting the rol record belonging to role_id
-            role = db.rol[role_id]
-            conflicting = check_conflicts(active_dienstverbanden=dienstverbanden,
-                                          role=role,
-                                          begin_date=begin if begin else None)
-            if conflicting:
-                # showing error message if a conflict occurs
-                return value, self.error_message
-            else:
-                pass
-        return value, None
-
-
-class IS_CAPITALIZED:
+class CAPITALIZE:
     """"Never returns an error, only converts string input value to a capitalized string.
 
     Example:
@@ -73,13 +7,13 @@ class IS_CAPITALIZED:
     """
 
     def __call__(self, value):
-        try:
-            return self.validate(value)
-        except Exception:
-            raise
+        return self.validate(value)
 
     def validate(self, value):
-        return value.capitalize(), None
+        if isinstance(value, str):
+            return value.capitalize(), None
+        else:
+            return value, 'Value has to be a string'
 
 
 db.define_table('dossier',
@@ -98,7 +32,7 @@ db.define_table('dossier',
 
 db.define_table('rol',
                 Field('naam', 'string', required=True, unique=True, requires=[IS_NOT_EMPTY(),
-                                                                              IS_CAPITALIZED(),
+                                                                              CAPITALIZE(),
                                                                               IS_ALPHANUMERIC(),
                                                                               IS_NOT_IN_DB(db, 'rol.naam')]
                       ),
@@ -109,7 +43,7 @@ db.define_table('rol',
 db.define_table('dienstverband',
                 # rol_id has to be a list of references for it to allow multiple roles within the same
                 # dienstverband record
-                Field('rol_id', 'list:reference rol', requires=NO_ROLE_OVERLAP(), label='Rol(len)'),
+                Field('rol_id', 'list:reference rol', label='Rol(len)'),
                 Field('begindatum', 'date', requires=IS_EMPTY_OR(IS_DATE())),
                 Field('einddatum', 'date', requires=IS_EMPTY_OR(IS_DATE())),
                 Field('dossier_id', 'reference dossier', required=True, label='Dossier'),

--- a/views/default/index.html
+++ b/views/default/index.html
@@ -1,6 +1,6 @@
 {{extend 'layout.html'}}
 
 
-{{=smartgrid}}
+{{=grid}}
 
 


### PR DESCRIPTION
* changed the NO_ROLE_OVERLAP() validator to a function that can be called by onvalidation
* optimized querying for actieve employment contract records
* conflicts can only occur for records that have an end date